### PR TITLE
Add building workflows

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -1,0 +1,41 @@
+name: Build project
+
+on:
+  workflow_dispatch:
+
+jobs:
+  buildForAllSupportedPlatforms:
+    name: Build for ${{ matrix.targetPlatform }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        targetPlatform:
+          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
+          - StandaloneWindows64 # Build a Windows 64-bit standalone.
+          - StandaloneLinux64 # Build a Linux 64-bit standalone.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Cache the libraries
+        uses: actions/cache@v3
+        with:
+          path: Library
+          key: Library-${{ matrix.targetPlatform }}
+          restore-keys: Library-
+      - name: Build the unity project
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: ${{ matrix.targetPlatform }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Build-${{ matrix.targetPlatform }}
+          path: build/${{ matrix.targetPlatform }}

--- a/.github/workflows/BuildAll.yaml
+++ b/.github/workflows/BuildAll.yaml
@@ -1,0 +1,15 @@
+name: Build Client + Server
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  callBuildServer:
+    name: Call the Build Server workflow
+    uses: ./.github/workflows/BuildServer.yaml
+    secrets: inherit
+  callBuildClient:
+    name: Call the Build Client workflow
+    uses: ./.github/workflows/BuildClient.yaml
+    secrets: inherit

--- a/.github/workflows/BuildClient.yaml
+++ b/.github/workflows/BuildClient.yaml
@@ -1,0 +1,43 @@
+name: Build Client (All Platforms)
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  buildForAllSupportedPlatforms:
+    name: Build client for ${{ matrix.targetPlatform }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        targetPlatform:
+          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
+          - StandaloneWindows64 # Build a Windows 64-bit standalone.
+          - StandaloneLinux64 # Build a Linux 64-bit standalone.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Cache the libraries
+        uses: actions/cache@v3
+        with:
+          path: Library
+          key: Library-${{ matrix.targetPlatform }}
+          restore-keys: Library-
+      - name: Build the unity project
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          buildName: ReConnect-${{ matrix.targetPlatform }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ReConnect-${{ matrix.targetPlatform }}
+          path: build/${{ matrix.targetPlatform }}

--- a/.github/workflows/BuildServer.yaml
+++ b/.github/workflows/BuildServer.yaml
@@ -1,19 +1,13 @@
-name: Build project
+name: Build Server (Linux only)
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
-  buildForAllSupportedPlatforms:
-    name: Build for ${{ matrix.targetPlatform }}
+  buildLinuxServer:
+    name: Build Linux Server
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        targetPlatform:
-          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
-          - StandaloneWindows64 # Build a Windows 64-bit standalone.
-          - StandaloneLinux64 # Build a Linux 64-bit standalone.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,7 +18,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: Library
-          key: Library-${{ matrix.targetPlatform }}
+          key: Library-LinuxServer
           restore-keys: Library-
       - name: Build the unity project
         uses: game-ci/unity-builder@v4
@@ -33,9 +27,12 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          targetPlatform: ${{ matrix.targetPlatform }}
+          buildName: ReConnect-Server-Linux
+          buildsPath: build/LinuxServer
+          targetPlatform: StandaloneLinux64
+          customParameters: -standaloneBuildSubtarget Server
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: Build-${{ matrix.targetPlatform }}
-          path: build/${{ matrix.targetPlatform }}
+          name: ReConnect-Server-Linux
+          path: build/LinuxServer


### PR DESCRIPTION
Add:
- **Build client workflow**: builds the client for Linux, Windows and MacOs (OSX) and upload artifacts
- **Build server workflow**: builds the server only for Linux and upload artifacts
- **Build client + server workflow**: call the two previous workflows at once

> [!NOTE]
> You can have access to the artifacts (the compiled game / server) by going in Actions, then clicking on the latest build run and scrolling down. You will see the Artifacts section containing all the builds (4 normally)

> [!NOTE]
> You can run the workflows by going in Actions. Click on the desired workflow on the left-hand menu (`Build Client + Server`,  `Build Client (All Platforms)` or `Build Server (Linux only)`). Then click on `Run workflow`, select the desired branch and confirm. This may take a while, please be patient :)