### PR TITLE
Stopped the sprinting animation when player stop moving

### DIFF
--- a/Assets/Scripts/Player/PlayerMovementsNetwork.cs
+++ b/Assets/Scripts/Player/PlayerMovementsNetwork.cs
@@ -192,7 +192,14 @@ namespace Reconnect.Player
             if (!_isMovementPressed && isWalking)
                 Animator.SetBool(_isWalkingHash, false);
 
+            // stop running if key released
             if (!_isRunning && isRunning)
+            {
+                Animator.SetBool(_isRunningHash, false);
+            }
+            
+            // stop running if no more moving (even though the key is still pressed)
+            if (!_isMovementPressed && isRunning)
                 Animator.SetBool(_isRunningHash, false);
 
             if (!_isCrouching && isCrouching)


### PR DESCRIPTION
The animation was being stopped only when the key is released however, when the character stop miving, even though the key is still pressed, the character should not be sprinting in place. Thuse, this case has been added and the issue is resolved